### PR TITLE
fix: use scExOrg in sample data save() (fixes #7)

### DIFF
--- a/R/schnapps-Main.R
+++ b/R/schnapps-Main.R
@@ -32,7 +32,7 @@
 #' @examples
 #' # create example data
 #' data("scEx", package = "SCHNAPPs")
-#' save(file = "scEx.Rdata", list = "scEx")
+#' save(file = "scEx.Rdata", list = "scExOrg")
 #' # use "scEx.Rdata" with load data functionality within the shiny app
 # Create a setup function that extracts the initialization part
 setup_schnapps_env <- function(localContributionDir = "~/Rstudio/shHubgit/Dummy/",
@@ -171,7 +171,7 @@ setup_schnapps_env <- function(localContributionDir = "~/Rstudio/shHubgit/Dummy/
 #' @examples
 #' # create example data
 #' data("scEx", package = "SCHNAPPs")
-#' save(file = "scEx.Rdata", list = "scEx")
+#' save(file = "scEx.Rdata", list = "scExOrg")
 #' # use "scEx.Rdata" with load data functionality within the shiny app
 # Create a setup function that extracts the initialization part
 schnapps <- function(..., port = NULL, launch.browser = getOption("shiny.launch.browser", interactive())) {

--- a/man/schnapps.Rd
+++ b/man/schnapps.Rd
@@ -40,6 +40,6 @@ Shiny app for the analysis of single cell data
 \examples{
 # create example data
 data("scEx", package = "SCHNAPPs")
-save(file = "scEx.Rdata", list = "scEx")
+save(file = "scEx.Rdata", list = "scExOrg")
 # use "scEx.Rdata" with load data functionality within the shiny app
 }

--- a/man/setup_schnapps_env.Rd
+++ b/man/setup_schnapps_env.Rd
@@ -47,6 +47,6 @@ Shiny app for the analysis of single cell data
 \examples{
 # create example data
 data("scEx", package = "SCHNAPPs")
-save(file = "scEx.Rdata", list = "scEx")
+save(file = "scEx.Rdata", list = "scExOrg")
 # use "scEx.Rdata" with load data functionality within the shiny app
 }

--- a/vignettes/pkdown/SCHNAPPs_usage.Rmd
+++ b/vignettes/pkdown/SCHNAPPs_usage.Rmd
@@ -125,7 +125,7 @@ An example data set is provided with the package. Load a small set of 200 cells 
 
 ```
 data("scEx", package = "SCHNAPPs")
-save(file = "scEx.Rdata", list = "scEx")
+save(file = "scEx.Rdata", list = "scExOrg")
 ```
 
 This file can be loaded once the app is started.


### PR DESCRIPTION
Closes #7

The object loaded with data("scEx", package = "SCHNAPPs") is scExOrg, not scEx. Update the list parameter in save() across vignettes, man, and R documentation.
